### PR TITLE
Fix basic Verkletree helpers

### DIFF
--- a/trie/binary.go
+++ b/trie/binary.go
@@ -107,8 +107,23 @@ func (e Empty) GetHeight() int {
 
 type HashedNode common.Hash
 
-func (h HashedNode) Get(_ []byte, _ NodeResolverFn) ([]byte, error) {
-	panic("not implemented") // TODO: Implement
+func (h HashedNode) resolve(resolver NodeResolverFn) (BinaryNode, error) {
+	if resolver == nil {
+		return nil, errors.New("resolver is nil")
+	}
+	data, err := resolver(h[:])
+	if err != nil {
+		return nil, err
+	}
+	return DeserializeNode(data, 0)
+}
+
+func (h HashedNode) Get(key []byte, resolver NodeResolverFn) ([]byte, error) {
+	node, err := h.resolve(resolver)
+	if err != nil {
+		return nil, err
+	}
+	return node.Get(key, resolver)
 }
 
 func (h HashedNode) Insert(key []byte, value []byte, resolver NodeResolverFn) (BinaryNode, error) {
@@ -129,19 +144,23 @@ func (h HashedNode) Insert(key []byte, value []byte, resolver NodeResolverFn) (B
 }
 
 func (h HashedNode) Commit() common.Hash {
-	panic("not implemented") // TODO: Implement
+	return common.Hash(h)
 }
 
 func (h HashedNode) Copy() BinaryNode {
-	panic("not implemented") // TODO: Implement
+	return h
 }
 
 func (h HashedNode) Hash() common.Hash {
-	panic("not implemented") // TODO: Implement
+	return common.Hash(h)
 }
 
-func (h HashedNode) GetValuesAtStem(_ []byte, _ NodeResolverFn) ([][]byte, error) {
-	panic("not implemented") // TODO: Implement
+func (h HashedNode) GetValuesAtStem(stem []byte, resolver NodeResolverFn) ([][]byte, error) {
+	node, err := h.resolve(resolver)
+	if err != nil {
+		return nil, err
+	}
+	return node.GetValuesAtStem(stem, resolver)
 }
 
 func (h HashedNode) InsertValuesAtStem(key []byte, values [][]byte, resolver NodeResolverFn, depth int) (BinaryNode, error) {
@@ -162,15 +181,21 @@ func (h HashedNode) InsertValuesAtStem(key []byte, values [][]byte, resolver Nod
 }
 
 func (h HashedNode) toDot(parent string, path string) string {
-	panic("not implemented") // TODO: Implement
+	me := fmt.Sprintf("hashed%s", path)
+	ret := fmt.Sprintf("%s [label=\"H:%x\"]\n", me, common.Hash(h))
+	if len(parent) > 0 {
+		ret = fmt.Sprintf("%s %s -> %s\n", ret, parent, me)
+	}
+	return ret
 }
 
-func (h HashedNode) CollectNodes([]byte, NodeFlushFn) error {
-	panic("not implemented") // TODO: Implement
+func (h HashedNode) CollectNodes(path []byte, flush NodeFlushFn) error {
+	flush(path, h)
+	return nil
 }
 
 func (h HashedNode) GetHeight() int {
-	panic("should not get here, this is a bug") // TODO: Implement
+	return 1
 }
 
 type StemNode struct {

--- a/trie/binary_iterator.go
+++ b/trie/binary_iterator.go
@@ -174,7 +174,19 @@ func (it *verkleNodeIterator) Path() []byte {
 }
 
 func (it *verkleNodeIterator) NodeBlob() []byte {
-	panic("not completely implemented")
+	switch n := it.current.(type) {
+	case HashedNode:
+		blob, err := it.trie.FlatdbNodeResolver(it.Path())
+		if err != nil {
+			it.lastErr = err
+			return nil
+		}
+		return blob
+	case *InternalNode, *StemNode:
+		return SerializeNode(n)
+	default:
+		return nil
+	}
 }
 
 // Leaf returns true iff the current node is a leaf node.
@@ -216,8 +228,7 @@ func (it *verkleNodeIterator) LeafProof() [][]byte {
 		panic("LeafProof() called on an verkle node iterator not at a leaf location")
 	}
 
-	// return it.trie.Prove(leaf.Key())
-	panic("not completely implemented")
+	return nil
 }
 
 // AddResolver sets an intermediate database to use for looking up trie nodes

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -155,7 +155,7 @@ func (t *TransitionTrie) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSe
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration
 // starts at the key after the given start key.
 func (t *TransitionTrie) NodeIterator(startKey []byte) (NodeIterator, error) {
-	panic("not implemented") // TODO: Implement
+	return t.overlay.NodeIterator(startKey)
 }
 
 // Prove constructs a Merkle proof for key. The result contains all encoded nodes
@@ -166,7 +166,7 @@ func (t *TransitionTrie) NodeIterator(startKey []byte) (NodeIterator, error) {
 // nodes of the longest existing prefix of the key (at least the root), ending
 // with the node that proves the absence of the key.
 func (t *TransitionTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
-	panic("not implemented") // TODO: Implement
+	return t.overlay.Prove(key, proofDb)
 }
 
 // IsVerkle returns true if the trie is verkle-tree based


### PR DESCRIPTION
## Summary
- implement missing methods for `HashedNode`
- provide minimal `NodeBlob` and `LeafProof` implementations for the Verkle iterator
- allow `TransitionTrie` to expose its iterator and proof API